### PR TITLE
Document that kernel source needs to be at ~/linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ git clone https://github.com/Poppy22/hawk.git
 
 Get the latest version of the Linux kernel:
 ```
+cd  # in your home directory
 git clone https://github.com/torvalds/linux.git
 ```
 


### PR DESCRIPTION
I think this is an implicit assumption in `compile_run.sh`

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR