### PR TITLE
Fixup bulid instructions for custom kernel

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -157,7 +157,7 @@ mkdir build && cd build
 - To build for running on your custom kernel:
 
   ```
-  cmake -Dbpf_INCLUDE_DIR=$KERNEL_TREE/tools/lib/ -Dbpf_LIB_PATH=$KERNEL_TREE/tools/lib/bpf -Dlinux_INCLUDE_DIR=$KERNEL_TREE/usr/include/.. ..
+  cmake -Dbpf_INCLUDE_DIR=$KERNEL_TREE/tools/lib/ -Dbpf_LIB_PATH=$KERNEL_TREE/tools/lib/bpf -Dlinux_INCLUDE_DIR=$KERNEL_TREE/usr/include/ -DVMLINUX_PATH=$KERNEL_TREE/vmlinux ..
   make
   ```
 


### PR DESCRIPTION
Looks like we changed the variable definition but forgot to update the docs
before merging. Also we missed the last arg to the cmake command.
